### PR TITLE
Implement voice recording with Whisper API

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -4,6 +4,7 @@ export default defineNuxtConfig({
   devtools: { enabled: true },
   modules: ['@nuxtjs/tailwindcss'],
   runtimeConfig: {
+    openaiApiKey: process.env.OPENAI_API_KEY,
     public: {
       SUPABASE_URL: process.env.SUPABASE_URL,
       SUPABASE_ANON_KEY: process.env.SUPABASE_ANON_KEY

--- a/pages/record.vue
+++ b/pages/record.vue
@@ -1,0 +1,50 @@
+<template>
+  <div class="p-4 space-y-4">
+    <h1 class="text-xl font-bold">音声入力</h1>
+    <div class="space-x-2">
+      <button @click="startRecording" :disabled="recording" class="bg-blue-500 text-white px-3 py-1 rounded">
+        録音開始
+      </button>
+      <button @click="stopRecording" :disabled="!recording" class="bg-red-500 text-white px-3 py-1 rounded">
+        録音停止
+      </button>
+    </div>
+    <p v-if="transcript" class="mt-4">{{ transcript }}</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+const recording = ref(false)
+const transcript = ref('')
+let mediaRecorder: MediaRecorder | null = null
+let chunks: BlobPart[] = []
+
+const startRecording = async () => {
+  const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+  mediaRecorder = new MediaRecorder(stream)
+  chunks = []
+  mediaRecorder.ondataavailable = (e) => {
+    chunks.push(e.data)
+  }
+  mediaRecorder.onstop = async () => {
+    const blob = new Blob(chunks, { type: 'audio/webm' })
+    const formData = new FormData()
+    formData.append('file', blob, 'audio.webm')
+    const res = await $fetch('/api/whisper', {
+      method: 'POST',
+      body: formData
+    })
+    // @ts-ignore
+    transcript.value = res.text || ''
+  }
+  mediaRecorder.start()
+  recording.value = true
+}
+
+const stopRecording = () => {
+  if (mediaRecorder) {
+    mediaRecorder.stop()
+    recording.value = false
+  }
+}
+</script>

--- a/server/api/whisper.post.ts
+++ b/server/api/whisper.post.ts
@@ -1,0 +1,34 @@
+import { defineEventHandler, readMultipartFormData } from 'h3'
+
+export default defineEventHandler(async (event) => {
+  const formData = await readMultipartFormData(event)
+  const file = formData?.find((f: any) => f.name === 'file')
+  if (!file) {
+    return { error: 'No file provided' }
+  }
+
+  const runtimeConfig = useRuntimeConfig()
+  const apiKey = runtimeConfig.openaiApiKey || ''
+
+  const openaiForm = new FormData()
+  const fileBlob = new File([file.data], file.filename || 'audio.webm', {
+    type: file.type || 'audio/webm'
+  })
+  openaiForm.append('file', fileBlob)
+  openaiForm.append('model', 'whisper-1')
+
+  const response = await fetch('https://api.openai.com/v1/audio/transcriptions', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`
+    },
+    body: openaiForm
+  })
+
+  if (!response.ok) {
+    const errText = await response.text()
+    return { error: errText }
+  }
+  const result = await response.json()
+  return result
+})


### PR DESCRIPTION
## Summary
- add OpenAI API key configuration
- build a `/record` page for voice recording
- implement server API route that proxies to Whisper

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684f46e7b058832b91e42c20c20a7b1c