### PR TITLE
Enable transcript editing and responsive layout

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,7 +1,7 @@
 <template>
-  <div>
+  <div class="min-h-screen flex flex-col bg-gray-50">
     <header class="bg-gray-800 text-white p-4">
-      <nav class="max-w-3xl mx-auto flex justify-between">
+      <nav class="mx-auto flex justify-between items-center w-full max-w-md sm:max-w-3xl">
         <NuxtLink to="/" class="font-bold">おんせい日記</NuxtLink>
         <div class="space-x-4">
           <NuxtLink to="/login" class="hover:underline">ログイン</NuxtLink>
@@ -9,7 +9,7 @@
         </div>
       </nav>
     </header>
-    <main class="p-4 max-w-3xl mx-auto">
+    <main class="flex-1 p-4 w-full mx-auto max-w-md sm:max-w-3xl">
       <slot />
     </main>
   </div>

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -1,6 +1,6 @@
 <!-- pages/login.vue -->
 <template>
-  <div class="p-4 max-w-md mx-auto">
+  <div class="p-4 max-w-md mx-auto bg-white rounded shadow">
     <h1 class="text-2xl font-bold mb-4">ログイン</h1>
     <input v-model="email" type="email" placeholder="メールアドレス" class="border p-2 w-full mb-2" />
     <button @click="login" class="bg-blue-500 text-white px-4 py-2 rounded w-full">ログイン</button>

--- a/pages/record.vue
+++ b/pages/record.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="p-4 space-y-4">
+  <div class="p-4 space-y-4 max-w-md mx-auto bg-white rounded shadow">
     <h1 class="text-xl font-bold">音声入力</h1>
     <div class="space-x-2">
       <button @click="startRecording" :disabled="recording" class="bg-blue-500 text-white px-3 py-1 rounded">
@@ -22,7 +22,12 @@
       </svg>
       <span>処理中...</span>
     </div>
-    <p v-else-if="transcript" class="mt-4">{{ transcript }}</p>
+    <textarea
+      v-else-if="transcript"
+      v-model="transcript"
+      rows="6"
+      class="mt-4 w-full p-2 border rounded"
+    />
   </div>
 </template>
 

--- a/pages/signup.vue
+++ b/pages/signup.vue
@@ -1,6 +1,6 @@
 <!-- pages/signup.vue -->
 <template>
-  <div class="p-4 max-w-md mx-auto">
+  <div class="p-4 max-w-md mx-auto bg-white rounded shadow">
     <h1 class="text-2xl font-bold mb-4">サインアップ</h1>
     <input v-model="email" type="email" placeholder="メールアドレス" class="border p-2 w-full mb-2" />
     <button @click="signup" class="bg-green-500 text-white px-4 py-2 rounded">アカウント作成</button>


### PR DESCRIPTION
## Summary
- allow editing of recorded text by turning the transcript into a textarea
- update default layout to use a full-screen, mobile friendly container
- style record, login and signup pages with card-like design for small screens

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850a4c74d24832b824cb47f78f010f5