### PR TITLE
Implement text-to-image feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Nuxt Minimal Starter
 
+This project demonstrates a simple voice diary that can generate images from text using the OpenAI API.
+
 Look at the [Nuxt documentation](https://nuxt.com/docs/getting-started/introduction) to learn more.
 
 ## Setup
@@ -20,6 +22,10 @@ yarn install
 bun install
 ```
 
+### Environment variables
+
+Set `OPENAI_API_KEY` in your environment so the server routes can access the OpenAI API.
+
 ## Development Server
 
 Start the development server on `http://localhost:3000`:
@@ -37,6 +43,8 @@ yarn dev
 # bun
 bun run dev
 ```
+
+After starting the dev server, visit `/record` to try recording audio and generating an image from the resulting text.
 
 ## Production
 

--- a/pages/record.vue
+++ b/pages/record.vue
@@ -23,6 +23,14 @@
       <span>処理中...</span>
     </div>
     <p v-else-if="transcript" class="mt-4">{{ transcript }}</p>
+    <div v-if="transcript" class="space-y-2">
+      <button @click="generateImage" :disabled="imageLoading" class="bg-green-500 text-white px-3 py-1 rounded">
+        {{ imageLoading ? '生成中...' : '画像生成' }}
+      </button>
+      <div v-if="imageUrl" class="mt-2">
+        <img :src="imageUrl" alt="生成された画像" class="max-w-full rounded" />
+      </div>
+    </div>
   </div>
 </template>
 
@@ -30,6 +38,8 @@
 const recording = ref(false)
 const transcript = ref('')
 const loading = ref(false)
+const imageLoading = ref(false)
+const imageUrl = ref('')
 
 let mediaRecorder: MediaRecorder | null = null
 let chunks: BlobPart[] = []
@@ -65,6 +75,21 @@ const stopRecording = () => {
   if (mediaRecorder) {
     mediaRecorder.stop()
     recording.value = false
+  }
+}
+
+const generateImage = async () => {
+  if (!transcript.value) return
+  imageLoading.value = true
+  try {
+    const res = await $fetch('/api/generate-image', {
+      method: 'POST',
+      body: { text: transcript.value }
+    })
+    // @ts-ignore
+    imageUrl.value = res.url || ''
+  } finally {
+    imageLoading.value = false
   }
 }
 </script>

--- a/server/api/generate-image.post.ts
+++ b/server/api/generate-image.post.ts
@@ -1,0 +1,64 @@
+import { defineEventHandler, readBody } from 'h3'
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody(event)
+  const text: string = body?.text || ''
+  if (!text) {
+    return { error: 'No text provided' }
+  }
+
+  const runtimeConfig = useRuntimeConfig()
+  const apiKey = runtimeConfig.openaiApiKey || ''
+
+  // Step 1: create a short English prompt from the provided text
+  const chatRes = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`
+    },
+    body: JSON.stringify({
+      model: 'gpt-3.5-turbo',
+      messages: [
+        {
+          role: 'system',
+          content:
+            'You create short English prompts for a watercolor style children\'s picture diary.'
+        },
+        { role: 'user', content: text }
+      ]
+    })
+  })
+
+  if (!chatRes.ok) {
+    const errText = await chatRes.text()
+    return { error: errText }
+  }
+
+  const chatData = await chatRes.json()
+  const prompt = chatData.choices?.[0]?.message?.content?.trim() || text
+
+  // Step 2: generate image using DALL-E
+  const imageRes = await fetch('https://api.openai.com/v1/images/generations', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`
+    },
+    body: JSON.stringify({
+      prompt,
+      n: 1,
+      size: '1024x1024',
+      model: 'dall-e-3'
+    })
+  })
+
+  if (!imageRes.ok) {
+    const errText = await imageRes.text()
+    return { error: errText }
+  }
+
+  const imageData = await imageRes.json()
+  const url = imageData.data?.[0]?.url
+  return { url }
+})


### PR DESCRIPTION
## Summary
- add documentation about OpenAI setup
- support generating images from transcript on `/record`
- implement `/api/generate-image` server route

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6850a5030c48832bb11978974c88ea63